### PR TITLE
feat!: add SDL_WINDOWEVENT_TAKE_FOCUS

### DIFF
--- a/src/event/window.rs
+++ b/src/event/window.rs
@@ -37,7 +37,8 @@ pub enum WindowEventDetails {
     FocusLost,
     /// The window was closed.
     Close,
-    /// The window given focus.
+    /// The window given focus. The application should call
+    /// SDL_SetWindowInputFocus() on the window or its subwindow, or ignore
     TakeFocus
 }
 

--- a/src/event/window.rs
+++ b/src/event/window.rs
@@ -37,6 +37,8 @@ pub enum WindowEventDetails {
     FocusLost,
     /// The window was closed.
     Close,
+    /// The window given focus.
+    TakeFocus
 }
 
 /// An event on interacting to the window.
@@ -87,7 +89,8 @@ impl From<bind::SDL_WindowEvent> for WindowEvent {
                 bind::SDL_WINDOWEVENT_FOCUS_GAINED => WindowEventDetails::FocusGained,
                 bind::SDL_WINDOWEVENT_FOCUS_LOST => WindowEventDetails::FocusLost,
                 bind::SDL_WINDOWEVENT_CLOSE => WindowEventDetails::Close,
-                _ => todo!(),
+                bind::SDL_WINDOWEVENT_TAKE_FOCUS => WindowEventDetails::TakeFocus,
+                other => todo!("{other} is not implemented"),
             },
         }
     }


### PR DESCRIPTION
fix #21.

**NOTE**: This change requires bump to `0.12.0`, because `WindowEventDetails` is accessiable from external crate and is not `#[non_exhaustive]`.