### PR TITLE
fix: Fallback to software rendering

### DIFF
--- a/src/video/renderer.rs
+++ b/src/video/renderer.rs
@@ -42,8 +42,9 @@ impl<'window> Renderer<'window> {
     /// Constructs a renderer from the window.
     #[must_use]
     pub fn new(window: &'window Window) -> Self {
-        let raw =
-            unsafe { bind::SDL_CreateRenderer(window.as_ptr(), -1, bind::SDL_RENDERER_SOFTWARE) };
+        let raw = unsafe {
+            bind::SDL_CreateRenderer(window.as_ptr(), -1, bind::SDL_RENDERER_SOFTWARE as u32)
+        };
         NonNull::new(raw).map_or_else(
             || Sdl::error_then_panic("Sdl renderer"),
             |renderer| Self { renderer, window },

--- a/src/video/renderer.rs
+++ b/src/video/renderer.rs
@@ -42,7 +42,8 @@ impl<'window> Renderer<'window> {
     /// Constructs a renderer from the window.
     #[must_use]
     pub fn new(window: &'window Window) -> Self {
-        let raw = unsafe { bind::SDL_CreateRenderer(window.as_ptr(), -1, 0) };
+        let raw =
+            unsafe { bind::SDL_CreateRenderer(window.as_ptr(), -1, bind::SDL_RENDERER_SOFTWARE) };
         NonNull::new(raw).map_or_else(
             || Sdl::error_then_panic("Sdl renderer"),
             |renderer| Self { renderer, window },


### PR DESCRIPTION
The rendering behavior on macOS with hardware acceleration is weird, so I decided to fallback the renderer to software rendering.
